### PR TITLE
Filter options update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-VITE_API_BASE=https://api.tourism.testingmachine.eu
-VITE_API_VERSION=v1
-VITE_DATABROWSER_BASE=https://databrowser.opendatahub.testingmachine.eu

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <div class="pb-lg-4 row gy-4 align-items-center">
         <Select
           class="col-12 col-xl-6"
-          @domain-change="(newDomain) => domain = newDomain"
+          :dataspaces="availableDataspaces"
+          @dataspace-change="(newDataspace) => selectedDataspace = newDataspace"
           @search-term-change="(changedTerm) => searchTerm = changedTerm"
         />
         <h4 class="col-12 col-xl-6 text-lg-end"><b>{{ filteredDatasets?.length }} Datasets</b></h4>
@@ -64,7 +65,10 @@ fetch(fontUrl)
   ];
 });
 
-const datasets = ref<Dataset[]>();
+const allDatasets = ref<Dataset[]>([]);
+const availableDataspaces = ref<string[]>([]);
+const selectedDataspace = ref<string>(""); // "" represents "All Dataspaces"
+const searchTerm = ref<string>("");
 
 const params = [
   "pagesize=1000",
@@ -79,38 +83,43 @@ fetchMetadata(
   // Remove [withoutDeprecated] to add Deprecated datasets into the list of datasets 
 )
 .then((data) => {
-  datasets.value = data;
+  allDatasets.value = data;
+
+  const dataspaces = new Set<string>();
+  data.forEach(dataset => {
+    if (typeof dataset.Dataspace === 'string' && dataset.Dataspace.trim() !== '') {
+      dataspaces.add(dataset.Dataspace.trim());
+    }
+  });
+  availableDataspaces.value = Array.from(dataspaces).sort();
 });
 
-const domain = ref("all");
-const searchTerm = ref<string>("");
-
 const filteredDatasets = computed(() => {
-  const byDomain = filterByDomain(datasets.value ?? [], domain.value);
-  const byTerm = filterByTerm(byDomain, searchTerm.value);
-  return byTerm;
+  let datasetsToFilter = allDatasets.value;
+  datasetsToFilter = filterByDataspace(datasetsToFilter, selectedDataspace.value);
+  datasetsToFilter = filterByTerm(datasetsToFilter, searchTerm.value);
+  return datasetsToFilter;
 })
 
-function filterByDomain(datasets: Dataset[], domain: string): Dataset[] {
-  if (domain === "all") {
+function filterByDataspace(datasets: Dataset[], dataspace: string): Dataset[] {
+  if (dataspace === "") {
     return datasets;
   } else {
-    return datasets.filter((dataset) => dataset.BaseUrl.includes(domain))
+    return datasets.filter((dataset) => dataset.Dataspace === dataspace);
   }
 }
 
-function filterByTerm(datasets: Dataset[], searchTerm: string): Dataset[] {
-  if (searchTerm.length > 0) {
-    return datasets.filter((dataset) => {
-      const titleIncludesTerm = dataset.Shortname.toLowerCase().includes(searchTerm.toLowerCase());
-      const descriptionIncludesTerm = dataset.ApiDescription?.en.toLowerCase().includes(searchTerm.toLowerCase());
-      return titleIncludesTerm || descriptionIncludesTerm;
-    })
-  } else {
+function filterByTerm(datasets: Dataset[], term: string): Dataset[] {
+  if (!term || term.trim().length === 0) {
     return datasets;
   }
+  const lowerCaseTerm = term.toLowerCase();
+  return datasets.filter((dataset) => {
+    const titleIncludesTerm = dataset.Shortname?.toLowerCase().includes(lowerCaseTerm);
+    const descriptionIncludesTerm = dataset.ApiDescription?.en?.toLowerCase().includes(lowerCaseTerm);
+    return titleIncludesTerm || descriptionIncludesTerm;
+  });
 }
-
 
 </script>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,12 +12,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <div class="container-fluid py-4">
       <div class="pb-lg-4 row gy-4 align-items-center">
         <Select
-          class="col-12 col-xl-6"
+          class="col-12"
           :dataspaces="availableDataspaces"
+          v-model:deprecatedFilterActive="showOnlyDeprecated"
           @dataspace-change="(newDataspace) => selectedDataspace = newDataspace"
           @search-term-change="(changedTerm) => searchTerm = changedTerm"
         />
-        <h4 class="col-12 col-xl-6 text-lg-end"><b>{{ filteredDatasets?.length }} Datasets</b></h4>
+        <h4 class="col-12 text-lg-end mt-3 mt-xl-0"><b>{{ filteredDatasets?.length }} Datasets</b></h4>
       </div>
       <div class="pt-4">
         <div class="row g-4">
@@ -41,7 +42,7 @@ import { computed, ref } from 'vue';
 import { Dataset } from './ts/types';
 import DatasetCard from "./components/DatasetCard.vue";
 import Select from './components/Select.vue';
-import { fetchMetadata, withParents, sorted, withoutDeprecated, apiBase, apiVersion } from "./ts/api";
+import { fetchMetadata, withParents, sorted, apiBase, apiVersion } from "./ts/api"; // Removed withoutDeprecated import as it's not used here
 
 const {
   fontUrl,
@@ -69,6 +70,7 @@ const allDatasets = ref<Dataset[]>([]);
 const availableDataspaces = ref<string[]>([]);
 const selectedDataspace = ref<string>(""); // "" represents "All Dataspaces"
 const searchTerm = ref<string>("");
+const showOnlyDeprecated = ref<boolean>(false); // State for the deprecated toggle
 
 const params = [
   "pagesize=1000",
@@ -98,6 +100,7 @@ const filteredDatasets = computed(() => {
   let datasetsToFilter = allDatasets.value;
   datasetsToFilter = filterByDataspace(datasetsToFilter, selectedDataspace.value);
   datasetsToFilter = filterByTerm(datasetsToFilter, searchTerm.value);
+  datasetsToFilter = filterByDeprecated(datasetsToFilter, showOnlyDeprecated.value);
   return datasetsToFilter;
 })
 
@@ -121,9 +124,16 @@ function filterByTerm(datasets: Dataset[], term: string): Dataset[] {
   });
 }
 
+function filterByDeprecated(datasets: Dataset[], onlyDeprecated: boolean): Dataset[] {
+  if (onlyDeprecated) {
+    return datasets.filter((dataset) => dataset.Deprecated === true);
+  } else {
+    return datasets;
+  }
+}
+
 </script>
 
 <style lang="scss">
 @import "./scss/styles.scss";
 </style>
-./ts/api./ts/types

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -7,75 +7,35 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <template>
   <div>
     <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-4">
-      <div
-        class="col-12 col-lg-4 position-relative"
-      >
-        <div
-          id="dropdown-title"
-          class="select-element w-100 position-relative border-0 form-control bg-light dropdown-toggle text-start"
-          @click="toggleDropdown"
+      <!-- Dataspace Dropdown -->
+      <div class="col-12 col-lg-4 position-relative">
+        <select
+          class="select-element w-100 form-select bg-light border-0"
+          v-model="selectedDataspace"
+          aria-label="Select Dataspace"
         >
-          {{ friendlyDomainNames[domain] }}
-        </div>
-        <div
-          id="dropdown"
-          class="w-100 position-absolute z-1 mt-2 card shadow"
-          :class="`${showDropdown ? 'd-block' : 'd-none'}`"
-        >
-          <ul class="mb-0 p-2 list-unstyled">
-            <li>
-              <div class="form-check">
-                <input
-                  class="form-check-input"
-                  id="all-radio"
-                  type="radio"
-                  value="all"
-                  v-model="domain"
-                >
-                <label class="form-check-label" for="all-radio">
-                  {{ friendlyDomainNames.all }}
-                </label>
-              </div>
-            </li>
-            <li>
-              <div class="form-check">
-                <input
-                  class="form-check-input"
-                  id="tourism-radio"
-                  type="radio"
-                  value="tourism"
-                  v-model="domain"
-                >
-                <label class="form-check-label" for="tourism-radio">
-                  {{ friendlyDomainNames.tourism }}
-                </label>
-              </div>
-            </li>
-            <li>
-              <div class="form-check">
-                <input
-                  class="form-check-input"
-                  id="mobility-radio"
-                  type="radio"
-                  value="mobility"
-                  v-model="domain"
-                >
-                <label class="form-check-label" for="mobility-radio">
-                  {{ friendlyDomainNames.mobility }}
-                </label>
-              </div>
-            </li>
-          </ul>
-        </div>
+          <option value="">All Dataspaces</option>
+          <option v-for="ds in dataspaces" :key="ds" :value="ds">
+            {{ formatDataspaceName(ds) }}
+          </option>
+        </select>
       </div>
+
+      <!-- Search Input -->
       <div class="col-12 col-lg-4 position-relative">
         <input
           type="text"
           class="select-element w-100 border-0 form-control bg-light text-start"
-          placeholder="Search elements"
+          placeholder="Search datasets"
           v-model="searchTerm"
-        >
-        <div @click="searchTerm = ''" class="close-icon"></div>
+        />
+        <div
+          v-show="searchTerm.length > 0"
+          @click="searchTerm = ''"
+          class="close-icon"
+          role="button"
+          aria-label="Clear search"
+        ></div>
       </div>
     </div>
   </div>
@@ -84,25 +44,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 
+const props = defineProps<{
+  dataspaces: string[];
+}>();
+
 const emit = defineEmits<{
-  domainChange: [domain: string];
+  dataspaceChange: [dataspace: string];
   searchTermChange: [searchTerm: string];
 }>()
 
-const showDropdown = ref(false);
-function toggleDropdown() {
-  showDropdown.value = !showDropdown.value;
-}
-
-const friendlyDomainNames: Record<string, string> = {
-  all: "All domains",
-  tourism: "Tourism",
-  mobility: "Mobility"
-}
-
-const domain = ref("all");
-watch(domain, (newValue) => emit("domainChange", newValue));
+const selectedDataspace = ref<string>("");
+watch(selectedDataspace, (newValue) => emit("dataspaceChange", newValue));
 
 const searchTerm = ref<string>("");
 watch(searchTerm, (newValue) => emit("searchTermChange", newValue));
+
+function formatDataspaceName(dataspace: string): string {
+  if (!dataspace) return '';
+  return dataspace.charAt(0).toUpperCase() + dataspace.slice(1);
+}
+
 </script>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -6,7 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <template>
   <div>
-    <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-4">
+    <!-- Wrap dropdown and search in one row -->
+    <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-4 align-items-lg-center">
       <!-- Dataspace Dropdown -->
       <div class="col-12 col-lg-4 position-relative">
         <select
@@ -38,19 +39,41 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         ></div>
       </div>
     </div>
+
+    <!-- Toggle on its own row -->
+    <div class="d-flex align-items-center gap-2 mt-3">
+      <!-- The toggle switch -->
+      <div class="toggle-switch">
+        <input
+          type="checkbox"
+          class="toggle-input"
+          id="deprecated-toggle"
+          :checked="deprecatedFilterActive"
+          @change="$emit('update:deprecatedFilterActive', ($event.target as HTMLInputElement).checked)"
+        />
+        <label for="deprecated-toggle" class="toggle-label"></label>
+      </div>
+      <!-- Text next to toggle -->
+      <label for="deprecated-toggle" class="mb-0" style="cursor: pointer;">
+        Deprecated
+      </label>
+    </div>
   </div>
 </template>
+
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 
 const props = defineProps<{
   dataspaces: string[];
+  deprecatedFilterActive: boolean;
 }>();
 
 const emit = defineEmits<{
   dataspaceChange: [dataspace: string];
   searchTermChange: [searchTerm: string];
+  'update:deprecatedFilterActive': [value: boolean];
 }>()
 
 const selectedDataspace = ref<string>("");

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -65,3 +65,56 @@ $light: #f5f5f5;
     }
   }
 }
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+
+/* Hide the checkbox visually */
+.toggle-input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  margin: 0; /* Remove any default spacing */
+}
+
+/* The toggle track */
+.toggle-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 20px;
+  background-color: #8b939b; /* Inactive: red */
+  border: 1px solid #8b939b;
+  border-radius: 20px;
+  transition: background-color 0.2s, border-color 0.2s;
+  cursor: pointer;
+}
+
+/* The sliding circle */
+.toggle-label::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  background-color: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+/* When checked, update colors and slide the circle */
+.toggle-input:checked + .toggle-label {
+  background-color: #000000; /* Active: green */
+  border-color: #000000;
+}
+
+.toggle-input:checked + .toggle-label::before {
+  transform: translate(20px, -50%);
+}

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -27,5 +27,6 @@ export interface Dataset {
     closed: number;
   };
 
+  Dataspace?: string | null;
   Parent?: Dataset;
 }


### PR DESCRIPTION
# Improved Data Space Selection

Previously, the list of data spaces was hardcoded and no longer reflected the actual data spaces available via the API.  
This update introduces dynamic, client-side filtering based on the `dataspace` field returned by the API, rather than relying on URL-based filtering.  
Users can now filter datasets accurately across all available data spaces.

![image](https://github.com/user-attachments/assets/fa9c8cfa-67c7-4f73-904a-ec4213076c88)

# Deprecated Datasets Filter

A new toggle allows users to filter on deprecated datasets. 
The logic matches the behavior of the Data Browser, and the visual style was adapted from it while aligning with our design guidelines.

![image](https://github.com/user-attachments/assets/29bb9a94-eea3-4e43-b9eb-db5412e0bc4c)  
![image](https://github.com/user-attachments/assets/046a644d-e9d6-4e75-b4cc-35d1c2cd2a9a)
